### PR TITLE
fix Python path

### DIFF
--- a/vacdec
+++ b/vacdec
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import zlib


### PR DESCRIPTION
Previously, the Python path was hardcoded to "/usr/bin/python".

In order to make packages available to "/usr/bin/python", you would
need to install them into the so-called global site-packages.

This is usally not a good idea, as this could break your operating
system (e.g. apt and other vital packages).

Usually, it is recommended to create a virtual environment, in which
an application's dependencies should be installed.

As the path was hardcoded to "/usr/bin/python", the installed packages
within the virtual env were not found, when you called
"./vacdec [image]".

Using "/usr/bin/env python" fixes this problem, without introducing
backwards incompatibility.