### PR TITLE
Add explanation to install zbar shared libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ how these certificates are encoded:
 
 ## setup
 
-You will need the python pillow, pyzbar, cbor2 and base45 packages.
+You will need the python pillow, pyzbar, cbor2 and base45 packages. Additionally, you need zbar. For Mac OS X, it can be installed via `brew install zbar`, on Debian systems via `apt install zbar`.
 You can install them via your distribution or via pip:
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ how these certificates are encoded:
 ## setup
 
 You will need the python pillow, pyzbar, cbor2 and base45 packages. Additionally, you need zbar. For Mac OS X, it can be installed via `brew install zbar`, on Debian systems via `apt install libzbar0`. [Source](https://pypi.org/project/pyzbar/)
+
 You can install them via your distribution or via pip:
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ how these certificates are encoded:
 
 ## setup
 
-You will need the python pillow, pyzbar, cbor2 and base45 packages. Additionally, you need zbar. For Mac OS X, it can be installed via `brew install zbar`, on Debian systems via `apt install zbar`.
+You will need the python pillow, pyzbar, cbor2 and base45 packages. Additionally, you need zbar. For Mac OS X, it can be installed via `brew install zbar`, on Debian systems via `apt install libzbar0`. [Source](https://pypi.org/project/pyzbar/)
 You can install them via your distribution or via pip:
 
 ```


### PR DESCRIPTION
On Linux and Mac OS X, you need to install zbar not only via pip, but also via brew or apt, to use pyzbar.
I added a small sentence to the README.