### PR TITLE
strip spaces and strip 2D coding prefix if it conforms to eHealth Network Version 1.3, section 2.3

### DIFF
--- a/vacdec
+++ b/vacdec
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import re
 import sys
 import zlib
 import pprint
@@ -31,7 +32,9 @@ else:
         sys.exit(1)
     cert = data[0].data.decode()
 
-b45data = cert.replace("HC1:", "")
+nospaces = cert.strip()
+
+b45data = nospaces if not re.match(r"[a-zA-Z0-9]{3}:", nospaces[:4]) else nospaces[4:]
 
 zlibdata = base45.b45decode(b45data)
 


### PR DESCRIPTION
Per specs https://ec.europa.eu/health/sites/default/files/ehealth/docs/digital-green-certificates_v3_en.pdf

  1. strips spaces around the string (typical issue when pasting base45 data through emails, ...)
  2. strip prefix, validated by regex, if it conforms with spec section "2.3 2D Code Versioning" (support for NL1, CZ1, HC2, ...)

This might result in trying to parse unsupported data (newer version of certificate) but the basics (b45+zlib) won't ever imho change, cbor will only contain different document

This should fix at least #15