### PR TITLE
Add verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Run:
 [image] can be an image in any format pillow supports, including of
 course PNG and JPG.
 
+The certificate can also be provided as string via command line with the option `-c` or from a text file with the option `-t`.
+
+There's also a verbose mode (`-v`) that translates the dates from Unix to UTC and decodes the json field values (name of the vaccine, type of test...).
+
 A test certificate can be found [here](https://github.com/Digitaler-Impfnachweis/certification-apis/tree/master/examples).
 
 ## author

--- a/vacdec
+++ b/vacdec
@@ -4,6 +4,7 @@ import sys
 import zlib
 import pprint
 import argparse
+from datetime import datetime
 
 import PIL.Image
 import pyzbar.pyzbar
@@ -17,6 +18,8 @@ ap.add_argument("-t", "--textfile", action="store_true",
                 help="Input as text file")
 ap.add_argument("-c", "--commandline", action="store_true",
                 help="Input via command line")
+ap.add_argument("-v", "--verbose", action="store_true",
+                help="Verbose output with the fields interpreted")
 args = ap.parse_args()
 
 if args.textfile:
@@ -39,4 +42,55 @@ cbordata = zlib.decompress(zlibdata)
 
 decoded = cbor2.loads(cbordata)
 
-pprint.pprint(cbor2.loads(decoded.value[2]))
+payload_json = cbor2.loads(decoded.value[2])
+
+if not args.verbose:
+	pprint.pprint(payload_json)
+else:
+
+	def utcformat(timestamp):
+		return datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S UTC')
+
+	tg = {'840539006':'COVID-19'}
+	vp = {'1119305005':'SARS-CoV-2 antigen vaccine', '1119349007':'SARS-CoV-2 mRNA vaccine', 'J07BX03':'covid-19 vaccines'}
+	mp = {'EU/1/20/1528':'Comirnaty', 'EU/1/20/1507':'Spikevax (previously COVID-19 Vaccine Moderna)', 'EU/1/21/1529':'Vaxzevria', 'EU/1/20/1525':'COVID-19 Vaccine Janssen', 'CVnCoV':'CVnCoV', 'NVX-CoV2373':'NVX-CoV2373', 'Sputnik-V':'Sputnik V', 'Convidecia':'Convidecia', 'EpiVacCorona':'EpiVacCorona','BBIBP-CorV':'BBIBP-CorV', 'Inactivated-SARS-CoV-2-Vero-Cell':'Inactivated SARS-CoV-2 (Vero Cell)', 'CoronaVac':'CoronaVac', 'Covaxin':'Covaxin (also known as BBV152 A, B, C)', 'Covishield':'Covishield (ChAdOx1_nCoV-19)', 'Covid-19-recombinant':'Covid-19 recombinant', 'R-COVI':'R-COVI', 'CoviVac':'CoviVac', 'Sputnik-Light':'Sputnik Light', 'Hayat-Vax':'Hayat-Vax', 'Abdala':'Abdala', 'WIBP-CorV':'WIBP-CorV', 'MVC-COV1901':'MVC COVID-19 vaccine'}
+	ma_v = {'ORG-100001699':'AstraZeneca AB','ORG-100030215':'Biontech Manufacturing GmbH', 'ORG-100001417':'Janssen-Cilag International', 'ORG-100031184':'Moderna Biotech Spain S.L.', 'ORG-100006270':'Curevac AG', 'ORG-100013793':'CanSino Biologics', 'ORG-100020693':'China Sinopharm International Corp. - Beijing location', 'ORG-100010771':'Sinopharm Weiqida Europe Pharmaceutical s.r.o. - Prague location', 'ORG-100024420':'Sinopharm Zhijun (Shenzhen) Pharmaceutical Co. Ltd. - Shenzhen location', 'ORG-100032020':'Novavax CZ AS', 'Gamaleya-Research-Institute':'Gamaleya Research Institute', 'Vector-Institute':'Vector Institute', 'Sinovac-Biotech':'Sinovac Biotech', 'Bharat-Biotech':'Bharat Biotech', 'ORG-100001981':'Serum Institute Of India Private Limited', 'Fiocruz':'Fiocruz', 'ORG-100007893':'R-Pharm CJSC', 'Chumakov-Federal-Scientific-Center':'Chumakov Federal Scientific Center for Research and Development of Immune-and-Biological Products', 'ORG-100023050':'Gulf Pharmaceutical Industries', 'CIGB':'Center for Genetic Engineering and Biotechnology (CIGB)', 'Sinopharm-WIBP':'Sinopharm - Wuhan Institute of Biological Products', 'ORG-100033914':'Medigen Vaccine Biologics Corporation'}
+	tt = {'LP6464-4':'Nucleic acid amplification with probe detection', 'LP217198-3':'Rapid immunoassay'}
+	ma_t = {"1833":"AAZ-LMB, COVID-VIRO", "1232":"Abbott Rapid Diagnostics, Panbio COVID-19 Ag Rapid Test", "1468":"ACON Laboratories, Inc, Flowflex SARS-CoV-2 Antigen rapid test", "1304":"AMEDA Labordiagnostik GmbH, AMP Rapid Test SARS-CoV-2 Ag", "1822":"Anbio (Xiamen) Biotechnology Co., Ltd, Rapid COVID-19 Antigen Test(Colloidal Gold)", "1815":"Anhui Deep Blue Medical Technology Co., Ltd, COVID-19 (SARS-CoV-2) Antigen Test Kit (Colloidal Gold) - Nasal Swab", "1736":"Anhui Deep Blue Medical Technology Co., Ltd, COVID-19 (SARS-CoV-2) Antigen Test Kit(Colloidal Gold)", "768":"ArcDia International Ltd, mariPOC SARS-CoV-2", "1654":"Asan Pharmaceutical CO., LTD, Asan Easy Test COVID-19 Ag", "2010":"Atlas Link Technology Co., Ltd., NOVA Test® SARS-CoV-2 Antigen Rapid Test Kit (Colloidal Gold Immunochromatography)", "1906":"Azure Biotech Inc, COVID-19 Antigen Rapid Test Device", "1870":"Beijing Hotgen Biotech Co., Ltd, Novel Coronavirus 2019-nCoV Antigen Test (Colloidal Gold)", "1331":"Beijing Lepu Medical Technology Co., Ltd, SARS-CoV-2 Antigen Rapid Test Kit", "1484":"Beijing Wantai Biological Pharmacy Enterprise Co., Ltd, Wantai SARS-CoV-2 Ag Rapid Test (FIA)", "1223":"BIOSYNEX S.A., BIOSYNEX COVID-19 Ag BSS", "1236":"BTNX Inc, Rapid Response COVID-19 Antigen Rapid Test", "1173":"CerTest Biotec, CerTest SARS-CoV-2 Card test", "1919":"Core Technology Co., Ltd, Coretests COVID-19 Ag Test", "1225":"DDS DIAGNOSTIC, Test Rapid Covid-19 Antigen (tampon nazofaringian)", "1375":"DIALAB GmbH, DIAQUICK COVID-19 Ag Cassette", "1244":"GenBody, Inc, Genbody COVID-19 Ag Test", "1253":"GenSure Biotech Inc, GenSure COVID-19 Antigen Rapid Kit (REF:P2004)", "1144":"Green Cross Medical Science Corp., GENEDIA W COVID-19 Ag", "1747":"Guangdong Hecin Scientific, Inc., 2019-nCoV Antigen Test Kit (colloidal gold method)", "1360":"Guangdong Wesail Biotech Co., Ltd, COVID-19 Ag Test Kit", "1437":"Guangzhou Wondfo Biotech Co., Ltd, Wondfo 2019-nCoV Antigen Test (Lateral Flow Method)", "1256":"Hangzhou AllTest Biotech Co., Ltd, COVID-19 and Influenza A+B Antigen Combo Rapid Test", "1363":"Hangzhou Clongene Biotech Co., Ltd, Covid-19 Antigen Rapid Test Kit", "1365":"Hangzhou Clongene Biotech Co., Ltd, COVID-19/Influenza A+B Antigen Combo Rapid Test", "1844":"Hangzhou Immuno Biotech Co.,Ltd, Immunobio SARS-CoV-2 Antigen ANTERIOR NASAL Rapid Test Kit (minimal invasive)", "1215":"Hangzhou Laihe Biotech Co., Ltd, LYHER Novel Coronavirus (COVID-19) Antigen Test Kit(Colloidal Gold)", "1392":"Hangzhou Testsea Biotechnology Co., Ltd, COVID-19 Antigen Test Cassette", "1767":"Healgen Scientific, Coronavirus Ag Rapid Test Cassette", "1263":"Humasis, Humasis COVID-19 Ag Test", "1333":"Joinstar Biomedical Technology Co., Ltd, COVID-19 Rapid Antigen Test (Colloidal Gold)", "1764":"JOYSBIO (Tianjin) Biotechnology Co., Ltd, SARS-CoV-2 Antigen Rapid Test Kit (Colloidal Gold)", "1266":"Labnovation Technologies Inc, SARS-CoV-2 Antigen Rapid Test Kit", "1267":"LumiQuick Diagnostics Inc, QuickProfile COVID-19 Antigen Test", "1268":"LumiraDX, LumiraDx SARS-CoV-2 Ag Test", "1180":"MEDsan GmbH, MEDsan SARS-CoV-2 Antigen Rapid Test", "1190":"möLab, COVID-19 Rapid Antigen Test", "1481":"MP Biomedicals, Rapid SARS-CoV-2 Antigen Test Card", "1162":"Nal von minden GmbH, NADAL COVID-19 Ag Test", "1420":"NanoEntek, FREND COVID-19 Ag", "1199":"Oncosem Onkolojik Sistemler San. ve Tic. A.S., CAT", "308":"PCL Inc, PCL COVID19 Ag Rapid FIA", "1271":"Precision Biosensor, Inc, Exdia COVID-19 Ag", "1341":"Qingdao Hightop Biotech Co., Ltd, SARS-CoV-2 Antigen Rapid Test (Immunochromatography)", "1097":"Quidel Corporation, Sofia SARS Antigen FIA", "1606":"RapiGEN Inc, BIOCREDIT COVID-19 Ag - SARS-CoV 2 Antigen test", "1604":"Roche (SD BIOSENSOR), SARS-CoV-2 Antigen Rapid Test", "1489":"Safecare Biotech (Hangzhou) Co. Ltd, COVID-19 Antigen Rapid Test Kit (Swab)", "1490":"Safecare Biotech (Hangzhou) Co. Ltd, Multi-Respiratory Virus Antigen Test Kit(Swab)  (Influenza A+B/ COVID-19)", "344":"SD BIOSENSOR Inc, STANDARD F COVID-19 Ag FIA", "345":"SD BIOSENSOR Inc, STANDARD Q COVID-19 Ag Test", "1319":"SGA Medikal, V-Chek SARS-CoV-2 Ag Rapid Test Kit (Colloidal Gold)", "2017":"Shenzhen Ultra-Diagnostics Biotec.Co.,Ltd, SARS-CoV-2 Antigen Test Kit", "1769":"Shenzhen Watmind Medical Co., Ltd, SARS-CoV-2 Ag Diagnostic Test Kit (Colloidal Gold)", "1574":"Shenzhen Zhenrui Biotechnology Co., Ltd, Zhenrui ®COVID-19 Antigen Test Cassette", "1218":"Siemens Healthineers, CLINITEST Rapid Covid-19 Antigen Test", "1114":"Sugentech, Inc, SGTi-flex COVID-19 Ag", "1466":"TODA PHARMA, TODA CORONADIAG Ag", "1934":"Tody Laboratories Int., Coronavirus (SARS-CoV 2) Antigen - Oral Fluid", "1443":"Vitrosens Biotechnology Co., Ltd, RapidFor SARS-CoV-2 Rapid Ag Test", "1246":"VivaChek Biotech (Hangzhou) Co., Ltd, Vivadiag SARS CoV 2 Ag Rapid Test", "1763":"Xiamen AmonMed Biotechnology Co., Ltd, COVID-19 Antigen Rapid Test Kit (Colloidal Gold)", "1278":"Xiamen Boson Biotech Co. Ltd, Rapid SARS-CoV-2 Antigen Test Card", "1456":"Xiamen Wiz Biotech Co., Ltd, SARS-CoV-2 Antigen Rapid Test", "1884":"Xiamen Wiz Biotech Co., Ltd, SARS-CoV-2 Antigen Rapid Test (Colloidal Gold)", "1296":"Zhejiang Anji Saianfu Biotech Co., Ltd, AndLucky COVID-19 Antigen Rapid Test", "1295":"Zhejiang Anji Saianfu Biotech Co., Ltd, reOpenTest COVID-19 Antigen Rapid Test", "1343":"Zhezhiang Orient Gene Biotech Co., Ltd, Coronavirus Ag Rapid Test Cassette (Swab)"}
+	tr = {'260415000':'Not detected', '260373001':'Detected'}
+
+	vaccine_fields = {'tg':tg, 'vp':vp, 'mp':mp, 'ma':ma_v}
+	test_fields = {'tg':tg, 'ma':ma_t, 'tr':tr}
+	recovery_fields = {'tg':tg}
+
+	print_format = "\nIssuer:\t\t\t{issuer}\nIssued At:\t\t{issued}\nExpires At:\t\t{expire}\nHealth Information:\n\n{health_json}"
+
+	issued = utcformat(payload_json[6])
+	expire = utcformat(payload_json[4])
+	issuer = payload_json[1]
+	del payload_json[6]
+	del payload_json[4]
+	del payload_json[1]
+
+	health_json = payload_json[-260][1]
+	del payload_json[-260]
+
+	if 'v' in health_json:
+		vaccine = health_json['v'][0]
+		for field in ['ma','mp','tg','vp']:
+			value = vaccine[field]
+			vaccine[field] = value + ' - ' + vaccine_fields[field][value]
+	elif 't' in health_json:
+		pass
+	elif 'r' in health_json:
+		pass
+
+	health_json = pprint.pformat(health_json)
+
+	print(print_format.format(
+		issuer=issuer,
+		issued=issued,
+		expire=expire,
+		health_json=health_json
+		))
+

--- a/vacdec
+++ b/vacdec
@@ -76,14 +76,22 @@ else:
 	del payload_json[-260]
 
 	if 'v' in health_json:
-		vaccine = health_json['v'][0]
-		for field in ['ma','mp','tg','vp']:
-			value = vaccine[field]
-			vaccine[field] = value + ' - ' + vaccine_fields[field][value]
+		cert_data = health_json['v'][0]
+		cert_fields = vaccine_fields
 	elif 't' in health_json:
-		pass
+		cert_data = health_json['t'][0]
+		cert_fields = test_fields
 	elif 'r' in health_json:
-		pass
+		cert_data = health_json['r'][0]
+		cert_fields = recovery_fields
+	else:
+		print('Certificate not recognized per version 1.3')
+		pprint.pprint(payload_json)
+		exit(1)
+
+	for field in cert_fields.keys():
+		value = cert_data[field]
+		cert_data[field] = value + ' - ' + cert_fields[field].get(value, 'Not defined in v1.3')
 
 	health_json = pprint.pformat(health_json)
 


### PR DESCRIPTION
### Changes

Added a verbose mode `-v` that translates the issue and expiration dates of the certificate from Unix timestamp to UTC in the format `YYYY-MM-DD HH:MM:SS`.

The verbose mode also decodes the json values for:

* Disease agent targeted
* Vaccine prophylaxis
* Vaccine medicinal product
* Vaccine manufacturer
* Test type
* Test manufacturer
* Test result

Although it shows the original encoded value too.

In general, it gives more information to the reader in a more structured way.

### Code Structure

I didn't want to modify the original structure of the code, so I just added the new functionality at the end of the file while preserving the original organization and functionality.